### PR TITLE
Feature/fix warnings - fixing gcc warnings for various lines

### DIFF
--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -559,8 +559,9 @@ bool CompareJunctions( int startLocation, char *cigar )
 									max = count[j] ;
 								sum += count[j] ;
 							}
-							if ( max > 0.8 * sum )
+							if ( max > 0.8 * sum ) {
 								validRead = false ;
+							}
 							count[0] = count[1] = count[2] = count[3] = count[4] = 0 ;
 						} break ;
 					case 'H':
@@ -574,8 +575,9 @@ bool CompareJunctions( int startLocation, char *cigar )
 			int sum = 0 ;
 			for ( j = 0 ; j < 5 ; ++j )
 			{
-				if ( count[j] > max )
+				if ( count[j] > max ) {
 					max = count[j] ;
+				}
 				sum += count[j] ;
 			}
 			if ( max > 0.8 * sum )

--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -974,7 +974,7 @@ int main( int argc, char *argv[] )
 					col[5], col[6], col[7], col[8], col[9],  col[10] ) ;
 					
 			flag = atoi( col[1] ) ;
-			if ( p = strstr( line, "NH" ) )
+			if ( (p = strstr( line, "NH" )) )
 			{
 				int k = 0 ;
 				p += 5 ;

--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -970,8 +970,8 @@ int main( int argc, char *argv[] )
 				break ;
 			if ( line[0] == '\0' || line[0] == '@' )
 				continue ;
-			sscanf( line, "%s%s%s%s%s%s%s%s%s%s%s", col, col + 1, col + 2, col + 3, col + 4, 
-					col + 5, col + 6, col + 7, col + 8, col + 9,  col + 10 ) ;
+			sscanf( line, "%s%s%s%s%s%s%s%s%s%s%s", col[0], col[1], col[2], col[3], col[4], 
+					col[5], col[6], col[7], col[8], col[9],  col[10] ) ;
 					
 			flag = atoi( col[1] ) ;
 			if ( p = strstr( line, "NH" ) )

--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -523,6 +523,8 @@ bool CompareJunctions( int startLocation, char *cigar )
 		}
 		else
 		{
+			/*
+			 * REMOVED: Unused variables
 			int softStart = -1 ;
 			int softEnd = 0 ;
 			if ( cigarSeg[0].type == 'S' )
@@ -530,6 +532,7 @@ bool CompareJunctions( int startLocation, char *cigar )
 			if ( cigarSeg[ ccnt - 1 ].type == 'S' )
 				softEnd = cigarSeg[ ccnt - 1 ].len ;
 			int readLen = strlen( col[9] ) ;
+			*/
 			int count[5] = { 0, 0, 0, 0, 0 } ;
 
 			int pos = 0 ;

--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -12,7 +12,7 @@
 
 #include "sam.h"
 
-#define LINE_SIZE 4097
+#define LINE_SIZE 8193
 #define QUEUE_SIZE 10001
 #define HASH_MAX 1000003
 

--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -546,7 +546,7 @@ bool CompareJunctions( int startLocation, char *cigar )
 					case 'I':
 						{
 							for ( j = 0 ; j < cigarSeg[i].len ; ++j )
-								++count[ nucToNum[  col[9][pos + j] - 'A' ] ] ;
+								++count[ (unsigned char) nucToNum[  col[9][pos + j] - 'A' ] ] ;
 							pos += j ;
 						} break ;
 					case 'N':


### PR DESCRIPTION
In summary, these were small changes with likely little to no effect on performance.
Included in the changes are:
- removal of unused variables via commenting out
- explicit casting, and use of indexing to implicitly decay array slices to expected type
- bracketing indented 'if statement' body to silence warnings about indentation