### PR TITLE
Increase cigar segment array and sequence size macro to allow junction finding for long reads

### DIFF
--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -490,7 +490,7 @@ bool CompareJunctions( int startLocation, char *cigar )
 	int num ;
 	int newJuncCnt = 0 ; // The # of junctions in the read, and the # of new junctions among them.
 	
-	struct _cigarSeg cigarSeg[1000] ; // A segment of the cigar.
+	struct _cigarSeg cigarSeg[2000] ; // A segment of the cigar.
 	int ccnt = 0 ; // cigarSeg cnt
 
 	j = 0 ;

--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -12,7 +12,7 @@
 
 #include "sam.h"
 
-#define LINE_SIZE 4097
+#define LINE_SIZE 8193
 #define QUEUE_SIZE 10001
 #define HASH_MAX 1000003
 


### PR DESCRIPTION
fixes https://github.com/splicebox/PsiCLASS/issues/36

Also includes some small improvements to silence compiler warnings!