### PR TITLE
Added missing default return value for IsGCRich function

### DIFF
--- a/alignments.hpp
+++ b/alignments.hpp
@@ -484,6 +484,7 @@ public:
 		}
 		if ( gcCnt >= threshold * b->core.l_qseq )
 			return true ;
+        return false;
 	}
 
 	void GetGeneralInfo( bool stopEarly = false )


### PR DESCRIPTION
This function appears to have undefined behaviour if the criteria for 'true' are not satisfied.