### PR TITLE
Fixing critical bug where complexity calculation is incorrect

### DIFF
--- a/FindJunction.cpp
+++ b/FindJunction.cpp
@@ -541,7 +541,7 @@ bool CompareJunctions( int startLocation, char *cigar )
 				switch ( cigarSeg[i].type )
 				{
 					case 'S':
-						pos += cigarSeg[i].len ;
+						pos += cigarSeg[i].len ; break ;
 					case 'M':
 					case 'I':
 						{


### PR DESCRIPTION
Partially fixes https://github.com/splicebox/PsiCLASS/issues/41

Due to a fallthrough to 'I' in the switch, an extra offset is added for any cigar strings containing 'S'. This causes the program to start reading into incorrect sequence characters from a previous alignment (or junk data, usually 0).